### PR TITLE
Bugfix display topics

### DIFF
--- a/src/lib/components/TopicView.svelte
+++ b/src/lib/components/TopicView.svelte
@@ -23,7 +23,7 @@
 					</a>
 				</td>
 				<td>{topic.professor}</td>
-				<td>{topic.specification}</td>
+				<td>{topic.subjectArea}</td>
 				<td>{topic.thesisType.join(', ')}</td>
 			</tr>
 		{/each}

--- a/src/lib/components/TopicView.svelte
+++ b/src/lib/components/TopicView.svelte
@@ -23,7 +23,7 @@
 					</a>
 				</td>
 				<td>{topic.professor}</td>
-				<td>{topic.subjectArea}</td>
+				<td>{topic.areaOfExpertise}</td>
 				<td>{topic.thesisType.join(', ')}</td>
 			</tr>
 		{/each}

--- a/src/routes/topic/[id]/+page.svelte
+++ b/src/routes/topic/[id]/+page.svelte
@@ -11,12 +11,16 @@
 
 <div class="card shadow-lg p-5 m-5 bg-base-100">
 	<h1 class="text-2xl mb-2">{data.topic.title} ({data.topic.thesisType})</h1>
+	Fachbereich: {data.topic.subjectArea}
+	<br />
 	Fachgebiet: {data.topic.areaOfExpertise}
 	<br />
 	<!--Makes E-Mail clickable and redirects to local E-Mailprovider-->
 	<a href="mailto:{data.topic.email}">Email: {data.topic.email}</a>
 	Ansprechperson: {data.topic.professor}
 	<br />	
+	Weitere Betreuende Person(en): {data.topic.supervisor}
+	<br />
 	Spezialisierung: {data.topic.specialization}
 	<br />
 	Technologien: {data.topic.technologies}

--- a/src/routes/topic/[id]/+page.svelte
+++ b/src/routes/topic/[id]/+page.svelte
@@ -11,13 +11,13 @@
 
 <div class="card shadow-lg p-5 m-5 bg-base-100">
 	<h1 class="text-2xl mb-2">{data.topic.title} ({data.topic.thesisType})</h1>
-	Spezialisierung: {data.topic.areaOfExpertise}
+	Fachgebiet: {data.topic.areaOfExpertise}
 	<br />
 	<!--Makes E-Mail clickable and redirects to local E-Mailprovider-->
 	<a href="mailto:{data.topic.email}">Email: {data.topic.email}</a>
 	Ansprechperson: {data.topic.professor}
-	<br />
-	Fachgebiet: {data.topic.specification}
+	<br />	
+	Spezialisierung: {data.topic.specification}
 	<br />
 	Technologien: {data.topic.technologies}
 	<br />

--- a/src/routes/topic/[id]/+page.svelte
+++ b/src/routes/topic/[id]/+page.svelte
@@ -17,7 +17,7 @@
 	<a href="mailto:{data.topic.email}">Email: {data.topic.email}</a>
 	Ansprechperson: {data.topic.professor}
 	<br />	
-	Spezialisierung: {data.topic.specification}
+	Spezialisierung: {data.topic.specialization}
 	<br />
 	Technologien: {data.topic.technologies}
 	<br />


### PR DESCRIPTION
Some topics showed "undefined" as an input or the wrong inputs at the wrong place which is now correct. I also added "Fachbereich" and "Weitere Betreuende Personen".